### PR TITLE
Fixed StreamExercises.map() method

### DIFF
--- a/src/main/java/com/insightfullogic/java8/examples/chapter3/StreamExercises.java
+++ b/src/main/java/com/insightfullogic/java8/examples/chapter3/StreamExercises.java
@@ -1,14 +1,11 @@
 package com.insightfullogic.java8.examples.chapter3;
 
-import com.insightfullogic.java8.examples.chapter1.Album;
 import com.insightfullogic.java8.examples.chapter1.Artist;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
 
 public class StreamExercises {
 
@@ -29,8 +26,11 @@ public class StreamExercises {
     // Advanced Exercise
     public static <T, R> List<R> map(Stream<T> stream, Function<T, R> mapper) {
         return stream.reduce(new ArrayList<>(), (acc, value) -> {
-            acc.add(mapper.apply(value));
-            return acc;
+        	// Make copy of list (modifying acc would violate contract of reduce method) 
+            ArrayList<R> result = new ArrayList<>();
+            result.addAll(acc);
+            result.add(mapper.apply(value));
+            return result;
         }, (left, right) -> {
             ArrayList<R> result = new ArrayList<>();
             result.addAll(left);

--- a/src/test/java/com/insightfullogic/java8/examples/chapter3/StreamExercisesTest.java
+++ b/src/test/java/com/insightfullogic/java8/examples/chapter3/StreamExercisesTest.java
@@ -1,7 +1,7 @@
 package com.insightfullogic.java8.examples.chapter3;
 
-import com.insightfullogic.java8.examples.chapter1.Album;
 import com.insightfullogic.java8.examples.chapter1.SampleData;
+
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -22,8 +22,16 @@ public class StreamExercisesTest {
 
     @Test
     public void mapExample() {
-        List<Integer> values = StreamExercises.map(Stream.of(1, 2, 3), x -> x + 1);
+        Stream<Integer> stream = Stream.of(1, 2, 3);
+		List<Integer> values = StreamExercises.map(stream, x -> x + 1);
         assertEquals(Arrays.asList(2, 3, 4), values);
     }
 
+    @Test
+    public void mapExampleParallel() {
+        Stream<Integer> parallelStream = Stream.of(1, 2, 3).parallel();
+		List<Integer> values = StreamExercises.map(parallelStream, x -> x + 1);
+        assertEquals(Arrays.asList(2, 3, 4), values);
+    }
+    
 }


### PR DESCRIPTION
Contract of Stream.reduce method requires that accumulator function
does not mutate its arguments. Previous implementation of
StreamExercises.map() method was using accumulator that were mutating
list passed as argument. Mutating parameters in accumulator function
results in incorrect behaviour when parallel stream is processed.

New implementation of StreamExercises.map() copies argument lists
in accumulator functions.

Unit test StreamExercisesTest was updated to check functionality of
StreamExercises.map() with parallel streams.