### PR TITLE
Wrong implementation of Artist.isFrom(String nationality) method

### DIFF
--- a/src/main/java/com/insightfullogic/java8/examples/chapter1/Artist.java
+++ b/src/main/java/com/insightfullogic/java8/examples/chapter1/Artist.java
@@ -63,7 +63,7 @@ public final class Artist {
     }
 
     public boolean isFrom(String nationality) {
-        return nationality.equals(nationality);
+        return this.nationality.equals(nationality);
     }
 
     @Override


### PR DESCRIPTION
Fixed the implementation of `Artist#isFrom(String nationality)` method, since it is supposed to compare the parameter with the class member.
