### PR TITLE
Lambda expression now returns DateFormatter, not a SimpleDateFormat.

### DIFF
--- a/src/main/java/com/insightfullogic/java8/answers/chapter2/Question2.java
+++ b/src/main/java/com/insightfullogic/java8/answers/chapter2/Question2.java
@@ -1,12 +1,12 @@
 package com.insightfullogic.java8.answers.chapter2;
 
 import java.text.SimpleDateFormat;
-import java.text.SimpleDateFormat;
+import javax.swing.text.DateFormatter;
 
 import static java.lang.ThreadLocal.withInitial;
 
 public class Question2 {
 
-     public final static ThreadLocal<SimpleDateFormat> formatter = ThreadLocal.withInitial(() -> new SimpleDateFormat("dd-MMM-yyyy") );
+     public final static ThreadLocal<DateFormatter> formatter = ThreadLocal.withInitial(() -> new DateFormatter(new SimpleDateFormat("dd-MMM-yyyy")));
 
 }

--- a/src/main/java/com/insightfullogic/java8/exercises/chapter2/Question2.java
+++ b/src/main/java/com/insightfullogic/java8/exercises/chapter2/Question2.java
@@ -3,14 +3,12 @@ package com.insightfullogic.java8.exercises.chapter2;
 import com.insightfullogic.java8.exercises.Exercises;
 
 import javax.swing.text.DateFormatter;
-import java.text.SimpleDateFormat;
-import java.time.format.DateTimeFormatter;
 
 import static java.lang.ThreadLocal.withInitial;
 
 public class Question2 {
 
-    public static ThreadLocal<SimpleDateFormat> formatter
+    public static ThreadLocal<DateFormatter> formatter
             = Exercises.replaceThisWithSolution();
 
 }

--- a/src/test/java/com/insightfullogic/java8/answers/chapter2/Question2Test.java
+++ b/src/test/java/com/insightfullogic/java8/answers/chapter2/Question2Test.java
@@ -14,7 +14,7 @@ public class Question2Test {
         cal.set(Calendar.YEAR, 1970);
         cal.set(Calendar.MONTH, Calendar.JANUARY);
         cal.set(Calendar.DAY_OF_MONTH, 1);
-        String formatted = Question2.formatter.get().format(cal.getTime());
+        String formatted = Question2.formatter.get().getFormat().format(cal.getTime());
         assertEquals("01-Jan-1970", formatted);
     }
 

--- a/src/test/java/com/insightfullogic/java8/exercises/chapter2/Question2Test.java
+++ b/src/test/java/com/insightfullogic/java8/exercises/chapter2/Question2Test.java
@@ -14,7 +14,7 @@ public class Question2Test {
         cal.set(Calendar.YEAR, 1970);
         cal.set(Calendar.MONTH, Calendar.JANUARY);
         cal.set(Calendar.DAY_OF_MONTH, 1);
-        String formatted = Question2.formatter.get().format(cal.getTime());
+        String formatted = Question2.formatter.get().getFormat().format(cal.getTime());
         assertEquals("01-Jan-1970", formatted);
     }
 


### PR DESCRIPTION
The exercise is supposed to use a Lambda expression that returns a DateFormatter, but only returns a SimpleDateFormat. Now this is fixed and it returns a DateFormatter.
fixed:
  src/main/java/com/insightfullogic/java8/answers/chapter2/Question2.java
  src/test/java/com/insightfullogic/java8/answers/chapter2/Question2Test.java
  src/main/java/com/insightfullogic/java8/exercises/chapter2/Question2.java
  src/test/java/com/insightfullogic/java8/exercises/chapter2/Question2Test.java