### PR TITLE
Fix twice call toString of StringConbiner, merge self issues

### DIFF
--- a/src/main/java/com/insightfullogic/java8/examples/chapter5/StringCombiner.java
+++ b/src/main/java/com/insightfullogic/java8/examples/chapter5/StringCombiner.java
@@ -2,55 +2,51 @@ package com.insightfullogic.java8.examples.chapter5;
 
 public class StringCombiner {
 
-    private final String delim;
     private final String prefix;
     private final String suffix;
-    private final StringBuilder builder;
+    private final String delim;
+    private final StringBuilder buIlder;
 
     public StringCombiner(String delim, String prefix, String suffix) {
-        this.delim = delim;
         this.prefix = prefix;
         this.suffix = suffix;
-        builder = new StringBuilder();
+        this.delim = delim;
+        this.buIlder = new StringBuilder();
     }
 
     // BEGIN add
-public StringCombiner add(String element) {
-    if (areAtStart()) {
-        builder.append(prefix);
-    } else {
-        builder.append(delim);
+    public StringCombiner add (String word) {
+        if(!this.areAtStart()) {
+            this.buIlder.append(delim);
+        }
+        this.buIlder.append(word);
+
+        return this;
     }
-    builder.append(element);
-    return this;
-}
     // END add
 
-    private boolean areAtStart() {
-        return builder.length() == 0;
-    }
-
     // BEGIN merge
-public StringCombiner merge(StringCombiner other) {
-	if (other.builder.length() > 0) {
-        if (areAtStart()) {
-        	builder.append(prefix);
-        } else {
-        	builder.append(delim);
+    public StringCombiner merge (StringCombiner other) {
+        if(!other.equals(this)) {
+            if(!other.areAtStart() && !this.areAtStart()){
+                other.buIlder.insert(0, this.delim);
+            }
+            this.buIlder.append(other.buIlder);
         }
-        builder.append(other.builder, prefix.length(), other.builder.length());
+        return this;
     }
-    return this;
-}
     // END merge
 
+    // BEGIN toString
     @Override
     public String toString() {
-        if (areAtStart()) {
-            builder.append(prefix);
-        }
-        builder.append(suffix);
-        return builder.toString();
+        return prefix + buIlder.toString() + suffix;
     }
+    // END toString
 
+    // BEGIN areAtStart
+    private boolean areAtStart() {
+        return buIlder.length() == 0;
+    }
+    // END areAtStart
 }

--- a/src/test/java/com/insightfullogic/java8/examples/chapter5/StringCombinerTest.java
+++ b/src/test/java/com/insightfullogic/java8/examples/chapter5/StringCombinerTest.java
@@ -1,0 +1,51 @@
+package com.insightfullogic.java8.examples.chapter5;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class StringCombinerTest {
+    private StringCombiner combiner;
+
+    @Before
+    public void before() {
+        this.combiner = new StringCombiner(", ", "[", "]");
+
+        combiner.add("A").add("B").add("C").add("D");
+    }
+
+    @Test
+    public void add() throws Exception {
+        assertEquals("[A, B, C, D]", combiner.toString());
+    }
+
+    @Test
+    public void mergeWithOther() throws Exception {
+        StringCombiner other = new StringCombiner(", ", "[", "]");
+
+        other.add("E").add("F").add("G");
+
+        this.combiner.merge(other);
+
+        assertEquals("[A, B, C, D, E, F, G]", this.combiner.toString());
+    }
+
+    @Test
+    public void mergeWithEmpty() {
+        this.combiner.merge(new StringCombiner(", ", "[", "]"));
+
+        assertEquals("[A, B, C, D]", this.combiner.toString());
+    }
+
+    @Test
+    public void mergeSelf() throws Exception {
+        assertEquals("[A, B, C, D]", this.combiner.merge(this.combiner).toString());
+    }
+
+    @Test
+    public void twiceCallToString() throws Exception {
+        assertEquals("[A, B, C, D]", this.combiner.toString());
+        assertEquals("[A, B, C, D]", this.combiner.toString());
+    }
+}


### PR DESCRIPTION
if you call 'combiner.toString()' twice and better, added ']' for each call.

so, here is my test case result.
![1](https://cloud.githubusercontent.com/assets/9916002/21761242/f454aedc-d694-11e6-9d8a-fb54acd050cc.PNG)

you can get following result, if you merge self as `combiner.merge(combiner)`
![2](https://cloud.githubusercontent.com/assets/9916002/21761295/54870e44-d695-11e6-8b54-e820aab4f9f5.PNG)

sorry, i can't speak English well  :joy: