### PR TITLE
SWE637 Fix flaky test RefactorTest

### DIFF
--- a/src/test/java/com/insightfullogic/java8/examples/chapter3/RefactorTest.java
+++ b/src/test/java/com/insightfullogic/java8/examples/chapter3/RefactorTest.java
@@ -6,8 +6,10 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.Collections;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
@@ -35,7 +37,10 @@ public class RefactorTest {
             Refactor.LongTrackFinder longTrackFinder = finder.get();
             Set<String> longTracks = longTrackFinder.findLongTracks(albums);
 
-            assertEquals("[Acknowledgement, Resolution]", longTracks.toString());
+	    List<String> result = new ArrayList<String>(longTracks);
+	    Collections.sort(result);
+
+            assertEquals("[Acknowledgement, Resolution]", result.toString());
 
             longTracks = longTrackFinder.findLongTracks(noTracks);
 


### PR DESCRIPTION
What is the purpose of this PR

    This PR fixes the error resulting from the flaky test: com.insightfullogic.java8.examples.chapter3.RefactorTest#allStringJoins
    The mentioned test may fail or pass without changes made to the source code when it is run in different JVMs due to HashSet's non-deterministic iteration order.

Why the tests fail

    This test fails because the test requests a set of strings returned from code in the Refactor class. This code returns a HashSet containing the string data. The test compares this result to a hard-coded string value. The problem is that the order of iteration is not guaranteed for HashSets. So, the test may fail as the given order can be different from the expected order.

Reproduce the test failure

    Run the tests with NonDex maven plugin. The commands to recreate the flaky test failures are:

    mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.insightfullogic.java8.examples.chapter3.RefactorTest#allStringJoins

    To run the test independently:
    mvn test -Dtest=com.insightfullogic.java8.examples.chapter3.RefactorTest#allStringJoins

Expected results

    This test should run successfully when run with NonDex.

Actual Result

    We get the following failure:
-------------------------------------------------------------------------------
Test set: com.insightfullogic.java8.examples.chapter3.RefactorTest
-------------------------------------------------------------------------------
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.029 sec <<< FAILURE! - in com.insightfullogic.java8.examples.chapter3.RefactorTest
allStringJoins(com.insightfullogic.java8.examples.chapter3.RefactorTest)  Time elapsed: 0.028 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[[Acknowledgement, Resolution]]> but was:<[[Resolution, Acknowledgement]]>
	at org.junit.Assert.assertEquals(Assert.java:115)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at com.insightfullogic.java8.examples.chapter3.RefactorTest.lambda$allStringJoins$0(RefactorTest.java:38)

Description of Fix

    I added some code to convert the HashSet into a list and then used Collections.sort to sort it before comparing to the hard-coded string value.
