### PR TITLE
The changes are made to the allStringJoins method.

### DIFF
--- a/src/test/java/com/insightfullogic/java8/examples/chapter3/RefactorTest.java
+++ b/src/test/java/com/insightfullogic/java8/examples/chapter3/RefactorTest.java
@@ -35,6 +35,11 @@ public class RefactorTest {
             Refactor.LongTrackFinder longTrackFinder = finder.get();
             Set<String> longTracks = longTrackFinder.findLongTracks(albums);
 
+            List<String> expectedTracks = Arrays.asList("Acknowledgement", "Resolution");
+            List<String> actualTracks = new ArrayList<>(longTracks);
+            Collections.sort(actualTracks);
+            assertEquals(expectedTracks, actualTracks);
+
             assertEquals("[Acknowledgement, Resolution]", longTracks.toString());
 
             longTracks = longTrackFinder.findLongTracks(noTracks);


### PR DESCRIPTION
**What is the purpose of this PR**
This PR fixes the error resulting from two flaky tests:allStringJoins(com.insightfullogic.java8.examples.chapter3.RefactorTest)  Time elapsed: 0.051 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[[Acknowledgement, Resolution]]> but was:<[[Resolution, Acknowledgement]]>
        at org.junit.Assert.assertEquals(Assert.java:115)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at com.insightfullogic.java8.examples.chapter3.RefactorTest.lambda$allStringJoins$0(RefactorTest.java:39)
The mentioned tests may fail or pass without changes made to the  an assertion mismatch.
**Why the tests fail**
The assertEquals method is checking if the output is exactly "[Acknowledgement, Resolution]". Since sets, by definition, do not guarantee order, the result "[Resolution, Acknowledgement]" is a valid outcome as well, depending on the order in which items are inserted or retrieved from the Set.
**Reproduce the test failure**
Run the tests with NonDex maven plugin. The commands to recreate the flaky test failures are:

mvn -pl cli edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.insightfullogic.java8.examples.chapter3.RefactorTest#allStringJoins

Fixing the flaky test now may prevent flaky test failures in future Java versions.

Expected results
<[[Acknowledgement, Resolution]]>
Actual Result
<[[Resolution, Acknowledgement]]>
We get the following failure for test com.insightfullogic.java8.examples.chapter3.RefactorTest.allStringJoins :
allStringJoins(com.insightfullogic.java8.examples.chapter3.RefactorTest)  Time elapsed: 0.039 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[[Acknowledgement, Resolution]]> but was:<[[Resolution, Acknowledgement]]>
        at org.junit.Assert.assertEquals(Assert.java:115)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at com.insightfullogic.java8.examples.chapter3.RefactorTest.lambda$allStringJoins$0(RefactorTest.java:41)

Results :

Failed tests:
  RefactorTest.allStringJoins:33->lambda$allStringJoins$0:41 expected:<[[Acknowledgement, Resolution]]> but was:<[[Resolution, Acknowledgement]]>
We get the following failure for test org.jboss.as.cli.impl.BootScriptInvokerTestCase#test:
<<< FAILURE! - in org.jboss.as.cli.impl.BootScriptInvokerTestCase [ERROR] test(org.jboss.as.cli.impl.BootScriptInvokerTestCase) Time elapsed: 0.066 s <<< FAILURE!
java.lang.AssertionError

**Fix**
 Before comparing, we convert the sets to lists, sort them, and then perform the comparison
List<String> expectedTracks = Arrays.asList("Acknowledgement", "Resolution");
List<String> actualTracks = new ArrayList<>(longTracks);
Collections.sort(actualTracks);
assertEquals(expectedTracks, actualTracks);
